### PR TITLE
feat: 兼容 mfsu，将 runtime 文件放置到 .umi 目录下

### DIFF
--- a/src/app.ts.tpl
+++ b/src/app.ts.tpl
@@ -1,5 +1,4 @@
-const react = require('react');
-// @ts-ignore
+import React from 'react';
 import allIcons from '@@/plugin-antd-icon/icons';
 
 export interface MenuDataItem {
@@ -15,7 +14,7 @@ export interface MenuDataItem {
   [key: string]: any;
 }
 function toHump(name: string) {
-  return name.replace(/\-(\w)/g, function(all, letter) {
+  return name.replace(/\-(\w)/g, function (all, letter) {
     return letter.toUpperCase();
   });
 }
@@ -31,7 +30,7 @@ function formatter(data: MenuDataItem[]): MenuDataItem[] {
       const NewIcon = allIcons[icon] || allIcons[`${v4IconName}Outlined`];
       if (NewIcon) {
         try {
-          item.icon = react.createElement(NewIcon);
+          item.icon = React.createElement(NewIcon);
         } catch (error) {
           console.log(error);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { IApi } from 'umi';
 import * as allIcons from '@ant-design/icons';
+import { join } from 'path';
+import { readFileSync } from 'fs';
 
 export interface MenuDataItem {
   children?: MenuDataItem[];
@@ -15,7 +17,7 @@ export interface MenuDataItem {
 }
 
 function toHump(name: string) {
-  return name.replace(/\-(\w)/g, function(all, letter) {
+  return name.replace(/\-(\w)/g, function (all, letter) {
     return letter.toUpperCase();
   });
 }
@@ -44,12 +46,12 @@ function formatter(data: MenuDataItem[]): MenuDataItem[] {
   return Array.from(new Set(icons));
 }
 
-export default function(api: IApi) {
+export default function (api: IApi) {
   api.onGenerateFiles(() => {
     const { userConfig } = api;
     const icons = formatter(userConfig.routes);
     let iconsString = icons.map(
-      iconName => `import ${iconName} from '@ant-design/icons/${iconName}'`,
+      (iconName) => `import ${iconName} from '@ant-design/icons/${iconName}'`,
     );
     api.writeTmpFile({
       path: './plugin-antd-icon/icons.ts',
@@ -61,6 +63,11 @@ export default {
 }
     `,
     });
+
+    api.writeTmpFile({
+      path: './plugin-antd-icon-config/app.ts',
+      content: readFileSync(join(__dirname, './app.ts.tpl'), 'utf-8'),
+    });
   });
-  api.addRuntimePlugin(() => require.resolve('./app.js'));
+  api.addRuntimePlugin(() => ['@@/plugin-antd-icon-config/app.ts']);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "experimentalDecorators": true,
-    "declaration": false
+    "declaration": false,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
原来直接在 .umi 中直接引入 lib/app.js 文件，无法在 mfsu 模式下使用。
变更将 app.ts 作为模版，直接生成到 .umi/plugin-antd-icon-config/app.ts 中，走 mfsu 编译